### PR TITLE
Return a 404 as opposed to a 400

### DIFF
--- a/src/utils/Uuid.ts
+++ b/src/utils/Uuid.ts
@@ -22,7 +22,7 @@ export function isUuid(uuid: string | undefined): boolean {
  */
 export function validateUuid(uuid: string | undefined): string {
   if (uuid == undefined || !isUuid(uuid)) {
-    throw new HttpException(400, 'Invalid UUID provided, you must provide a valid UUID')
+    throw new HttpException(404, 'Invalid UUID provided, you must provide a valid UUID')
   }
 
   return uuid


### PR DESCRIPTION
The API currently returns a `400` when an invalid UUID is provided.

![image](https://user-images.githubusercontent.com/49261529/109233245-62acab80-777e-11eb-8489-e906ad86b1bc.png)

The documentation, however, states that a `404` should be returned instead.

![image](https://user-images.githubusercontent.com/49261529/109233284-748e4e80-777e-11eb-9f1d-d84b2616ceaa.png)

Either the API or the documentation is incorrect.